### PR TITLE
fix: remove links from home page

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -9,8 +9,3 @@ layout: ../layouts/genericMarkdownFile.astro
 Welcome to CTD Course Pages! This is a heavily WIP website which will
 become the future home of CTD curriculum content (for at least the
 node-express course)!
-
-Here are some entrypoints into the content we are working on:
-
-- [Node Express Course](/node-express/home)
-- [Homework Tips](/general/homework-tips)


### PR DESCRIPTION
Node-express link was dead & we have nav now
