### PR TITLE
Non-lesson-specific feedback for Astro node course pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@astrojs/mdx": "^0.19.7",
         "@astrojs/react": "^2.1.3",
         "@astrojs/tailwind": "^3.1.2",
-        "@tailwindcss/typography": "^0.5.9",
+        "@tailwindcss/typography": "^0.5.10",
         "@types/node": "^20.2.5",
         "@types/react": "^18.2.5",
         "@types/react-dom": "^18.2.4",
@@ -1192,9 +1192,9 @@
       }
     },
     "node_modules/@tailwindcss/typography": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
-      "integrity": "sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.10.tgz",
+      "integrity": "sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==",
       "dependencies": {
         "lodash.castarray": "^4.4.0",
         "lodash.isplainobject": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@astrojs/mdx": "^0.19.7",
     "@astrojs/react": "^2.1.3",
     "@astrojs/tailwind": "^3.1.2",
-    "@tailwindcss/typography": "^0.5.9",
+    "@tailwindcss/typography": "^0.5.10",
     "@types/node": "^20.2.5",
     "@types/react": "^18.2.5",
     "@types/react-dom": "^18.2.4",

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,37 +1,55 @@
 import { HamburgerIcon } from "./hamburger";
 import { navLocations } from "./nav";
 
-export const Header = () => (
-  <header className="flex gap-3 p-4 bg-salmon-300">
-    <a href="/">
-      <img
-        className="sm:w-48 bg-salmon-100 p-2 rounded-xl"
-        src="/ctdLogo.webp"
-      />
-    </a>
-    <div className="gap-2 items-center sm:flex hidden">
-      {navLocations.map(({ href, display }) =>
-        typeof display === "string" ? (
-          <NavLink key={href} href={href}>
-            {display}
-          </NavLink>
-        ) : (
-          display
-        )
-      )}
-    </div>
-    <a className="sm:hidden" href="/mobile-nav">
-      <HamburgerIcon />
-    </a>
-  </header>
-);
+export const Header: React.FC<{ currentPath: string }> = ({ currentPath }) => {
+  const isActive = (href: string) => {
+    const path = currentPath || "/";
+    if (href === "/") {
+      return path === href;
+    }
+    return path.startsWith(href);
+  };
+
+  return (
+    <header className="flex gap-3 p-4 bg-salmon-300">
+      <a href="/">
+        <img
+          className="sm:w-48 bg-salmon-100 p-2 rounded-xl"
+          src="/ctdLogo.webp"
+        />
+      </a>
+      <div className="gap-2 items-center sm:flex hidden">
+        {navLocations.map(({ href, display }) =>
+          typeof display === "string" ? (
+            <NavLink key={href} href={href} active={isActive(href)}>
+              {display}
+            </NavLink>
+          ) : (
+            display
+          )
+        )}
+      </div>
+      <a className="sm:hidden" href="/mobile-nav">
+        <HamburgerIcon />
+      </a>
+    </header>
+  );
+};
 
 // This lives here because we probably only want this styling in the header
-const NavLink = (props: { children: React.ReactNode; href: string }) => (
-  <a
-    className="underline font-bold hover:bg-salmon-100 rounded p-1 transition"
-    href={props.href}
-  >
-    {props.children}
-  </a>
-);
+const NavLink = (props: {
+  children: React.ReactNode;
+  href: string;
+  active: boolean;
+}) => {
+  return (
+    <a
+      className={`underline font-bold hover:bg-salmon-100 rounded p-1 transition ${
+        props.active ? "bg-salmon-50" : ""
+      }`}
+      href={props.href}
+    >
+      {props.children}
+    </a>
+  );
+};

--- a/src/layouts/genericMarkdownFile.astro
+++ b/src/layouts/genericMarkdownFile.astro
@@ -25,7 +25,7 @@ export interface Props {
   thumbnail={Astro.props.thumbnail}
 >
   <div class="flex flex-col min-h-screen">
-    <Header />
+    <Header currentPath={Astro.url.pathname} />
     <div
       class="flex flex-grow pt-8 bg-salmon-50 sm:bg-white justify-center w-screen"
     >

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -15,7 +15,7 @@ node-express course)!
 <CardButton
   text="Node/Express Class"
   bgUrl="/node-express.webp"
-  link="/node-express/classLinks"
+  link="/node-express"
 />
 <CardButton
   text="Ruby on Rails Class"

--- a/src/pages/node-express.md
+++ b/src/pages/node-express.md
@@ -8,6 +8,37 @@ description: Homepage for the Node & Express Code the Dream Course
 
 Welcome! This is the home page for the Node and Express course.
 
+## Class Links
+
+- [Lesson 1 - Learning Materials](/node-express/lesson1-m1)
+- [Lesson 1 - Assignment](/node-express/lesson1-a1)<br/><br/>
+- [Lesson 2 - Learning Materials](/node-express/lesson2-m1)
+- [Lesson 2 - Assignment](/node-express/lesson2-a1)<br/><br/>
+- [Lesson 3 - Learning Materials](/node-express/lesson3-m1)
+- [Lesson 3 - Assignment](/node-express/lesson3-a1)<br/><br/>
+- [Lesson 4 - Learning Materials](/node-express/lesson4-m1)
+- [Lesson 4 - Assignment](/node-express/lesson4-a1)<br/><br/>
+- [Lesson 5 - Learning Materials](/node-express/lesson5-m1)
+- [Lesson 5 - Assignment](/node-express/lesson5-a1)<br/><br/>
+- [Lesson 6 - Learning Materials](/node-express/lesson6-m1)
+- [Lesson 6 - Assignment](/node-express/lesson6-a1)<br/><br/>
+- [Lesson 7 - Learning Materials](/node-express/lesson7-m1)
+- [Lesson 7 - Assignment](/node-express/lesson7-a1)<br/><br/>
+- [Lesson 8 - Learning Materials](/node-express/lesson8-m1)
+- [Lesson 8 - Assignment](/node-express/lesson8-a1)<br/><br/>
+- [Lesson 9 - Learning Materials](/node-express/lesson9-m1)
+- [Lesson 9 - Assignment](/node-express/lesson9-a1)<br/><br/>
+- [Lesson 10 - Learning Materials](/node-express/lesson10-m1)
+- [Lesson 10 - Assignment](/node-express/lesson10-a1)<br/><br/>
+- [Lesson 11 - Learning Materials](/node-express/lesson11-m1)
+- [Lesson 11 - Assignment](/node-express/lesson11-a1)<br/><br/>
+- [Lesson 12 - Learning Materials](/node-express/lesson12-m1)
+- [Lesson 12 - Assignment](/node-express/lesson12-a1)<br/><br/>
+- [Lesson 13 - Learning Materials](/node-express/lesson13-m1)
+- [Lesson 13 - Assignment](/node-express/lesson13-a1)<br/><br/>
+- [Lesson 14 - Learning Materials](/node-express/lesson14-m1)
+- [Lesson 14 - Assignment](/node-express/lesson14-a1)<br/><br/>
+
 ## Reviewer Notes
 
 For reviewers, mentors, or student-leaders to reference during the Node and

--- a/src/pages/node-express/node-setup.md
+++ b/src/pages/node-express/node-setup.md
@@ -49,7 +49,7 @@ You should also configure VSCode to handle line ends as Linux does, and to use G
 code .
 ```
 
-You can then bring up the settings for VSCode by typing Ctrl, (the ctrl key plus the comma). The settings has a Search settings entry field. Type line end in that entry field. You will then be able to set the Eol to /n which is what you want. Then do a Search settings for: terminal integrated default profile windows. This brings up a dropdown, from which you should choose Git Bash.
+You can then bring up the settings for VSCode by typing Ctrl, (the Ctrl key plus the comma). The settings has a Search settings entry field. Type line end in that entry field. You will then be able to set the Eol to /n which is what you want. Then do a Search settings for: terminal integrated default profile windows. This brings up a dropdown, from which you should choose Git Bash.
 
 That completes Windows specific setup.
 


### PR DESCRIPTION
## Overview of changes

*   Bumped tailwind typography version by 1 so that text wrapped in the [Keyboard Input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd) element (`<kbd>`) would have some automatic styling

![](https://github.com/Code-the-Dream-School/school-pages/assets/9094098/3ea4c605-d40d-4951-b27b-5b57e3efafee)

*   Updated the navbar component (`header.tsx`) to highlight which section you are currently on, by passing in the current url from the server-rendered `genericMarkdownFile.astro`  page
*   It seems like we have two places to list node-express course paegs; one was `/node-express/classLinks` (backed by the `src/pages/node-express/classLinks.md` file) and one was just `/node-express` (backed by the `src/pages/node-express.md` file). It wasn't clear to me that there's any particular reason to have both; so I just moved all the lesson material links to `node-express.md` since that's where the navbar links to and updated the one button that was going to `classLinks` to go there instead. If we don't have any specific use for `classLinks.md` maybe we can just delete it, and move any remaining links from there over as well?) Right now, the difference is that that markdown file also includes the. node cheatsheet and node setup files. Both files have reviewer notes linked -- is the goal to eventually hide or gate the reviewer notes from students at all?.

![](https://github.com/Code-the-Dream-School/school-pages/assets/9094098/5ef71e79-66ba-4995-ab0b-3b1d45d227d4)